### PR TITLE
Set image fit to cover

### DIFF
--- a/lib/widgets/preview_image.dart
+++ b/lib/widgets/preview_image.dart
@@ -15,7 +15,7 @@ class PreviewImage extends StatelessWidget {
         padding: EdgeInsets.all(10),
         child: CachedNetworkImage(
           imageUrl: _image,
-          fit: BoxFit.fill,
+          fit: BoxFit.cover,
           height: (MediaQuery.of(context).size.width -
                   MediaQuery.of(context).padding.top -
                   MediaQuery.of(context).padding.bottom) *


### PR DESCRIPTION
Hey! Thank you for the awesome package.

I think the image with fill property looks weird for some images.
So, I think it is better to use `cover` instead of `fit`.

Please let me know your thoughts.

Set image `fit` to `BoxFit.cover` so that image does not get stretched.

![Github demo](https://user-images.githubusercontent.com/20378877/94768419-217ebe00-03cf-11eb-847e-a6f48e9d5111.png)

